### PR TITLE
CoAP Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/ota-request.js
+++ b/ota-request.js
@@ -1,0 +1,16 @@
+var coap = require('coap');
+
+var req = coap.request('coap://[::1]/0/20')
+
+// edit this to adjust max packet
+req.setOption('Block2', new Buffer([0x2]))
+
+req.on('response', function(res) {
+  //res.pipe(process.stdout)
+  console.log( res.payload )
+  res.on('end', function() {
+    process.exit(0)
+  })
+})
+
+req.end()

--- a/ota-request.js
+++ b/ota-request.js
@@ -1,6 +1,6 @@
 var coap = require('coap');
 
-var req = coap.request('coap://[::1]/0/20')
+var req = coap.request('coap://[fe80::c36:8dff:fe3a:84a5]/0/20')
 
 // edit this to adjust max packet
 req.setOption('Block2', new Buffer([0x2]))

--- a/ota-server.js
+++ b/ota-server.js
@@ -1,12 +1,9 @@
 var http = require('http');
+var coap = require('coap');
 var url = require('url');
 var fs = require('fs');
 
-var server = http.createServer();
-//  Our OTA server will use IPv6 address bbbb::1, port 3003
-//  Feel free to use any IPv4 or IPv6 address that your nodes can resolve!
-host = "bbbb::1";
-port = 3003;
+var server = coap.createServer({ type: 'udp6' });
 
 //  Configure the firmware to be served OTA
 var firmware_binary = fs.readFileSync( process.argv[2] );
@@ -23,20 +20,20 @@ server.on('request', function(req, res) {
   if (data_start_position >= firmware_binary.length) {
     //  If there's no more firmware, just send back an EOF message!
     console.log("\tFirmware Binary: Reached End Of File.");
-    res.writeHead( 200, {'Content-Type': 'text/plain'} );
     res.end("EOF");
   } else {
     //  Make sure we don't read past the end of the firmware.
     var data_end_position = Math.min( (data_start_position + data_length), firmware_binary.length );
     data = firmware_binary.slice( data_start_position, data_end_position );
     console.log("\tSending " + data.length + " bytes.");
-    res.writeHead( 200, {'Content-Type': 'application/octet-stream'} );
     res.end( data );
   }
 });
 
 server.on('listening', function() {
-  console.log("OTA server listening on http://" + this.address().address + ":" + this.address().port + "/");
+
 });
 
-server.listen(port, host);
+server.listen( function() {
+  console.log("OTA server listening on coap://[::1]:5683");
+});

--- a/ota-server.js
+++ b/ota-server.js
@@ -7,12 +7,28 @@ var server = coap.createServer({ type: 'udp6' });
 
 //  Configure the firmware to be served OTA
 var firmware_binary = fs.readFileSync( process.argv[2] );
+console.log( firmware_binary.length );
 
 //  Here's where we process HTTP requests for chunks of the firmware_binary
 server.on('request', function(req, res) {
   // (1) Parse URL path to obtain the data_start and data_length parameters
+  console.log( req.url );
   request_parts = url.parse( req.url );
   path_arguments = request_parts.path.split("/");
+  
+
+  if (path_arguments[1] == "ota") {
+    //var data_start = parseInt( path_arguments[2] );
+    console.log( req.url );
+    data_start = req.payload.readUInt32LE(0);
+    console.log("Requesting firmware starting from address " + data_start);
+    
+    res.end( firmware_binary.slice(data_start, firmware_binary.length) );
+    //res.end( firmware_binary );
+    return;
+  }
+
+/*
   var data_start_position = parseInt( path_arguments[1] );
   var data_length = parseInt( path_arguments[2] );
   console.log( "Requesting data:\t" + data_start_position + "\t" + (data_start_position+data_length) );
@@ -28,10 +44,7 @@ server.on('request', function(req, res) {
     console.log("\tSending " + data.length + " bytes.");
     res.end( data );
   }
-});
-
-server.on('listening', function() {
-
+*/
 });
 
 server.listen( function() {

--- a/ota-server.js
+++ b/ota-server.js
@@ -11,6 +11,7 @@ var firmware_binary = fs.readFileSync( process.argv[2] );
 //  Here's where we process HTTP requests for chunks of the firmware_binary
 server.on('request', function(req, res) {
   // (1) Parse URL path to obtain the data_start and data_length parameters
+  console.log("Received CoAP request: " + req.url);
   request_parts = url.parse( req.url );
   path_arguments = request_parts.path.split("/");
   var data_start_position = parseInt( path_arguments[1] );

--- a/ota-server.js
+++ b/ota-server.js
@@ -1,4 +1,3 @@
-var http = require('http');
 var coap = require('coap');
 var url = require('url');
 var fs = require('fs');
@@ -8,7 +7,7 @@ var server = coap.createServer({ type: 'udp6' });
 //  Configure the firmware to be served OTA
 var firmware_binary = fs.readFileSync( process.argv[2] );
 
-//  Here's where we process HTTP requests for chunks of the firmware_binary
+//  Here's where we process CoAP requests for chunks of the firmware_binary
 server.on('request', function(req, res) {
   // (1) Parse URL path to obtain the data_start and data_length parameters
   console.log("Received CoAP request: " + req.url);

--- a/ota-server.js
+++ b/ota-server.js
@@ -6,44 +6,26 @@ var server = coap.createServer({ type: 'udp6' });
 
 //  Configure the firmware to be served OTA
 var firmware_binary = fs.readFileSync( process.argv[2] );
-console.log( firmware_binary.length );
 
 //  Here's where we process CoAP requests for chunks of the firmware_binary
 server.on('request', function(req, res) {
-  // (1) Parse URL path to obtain the data_start and data_length parameters
+  // (1) Parse URL path to see if this is an OTA request
   console.log("Received CoAP request: " + req.url);
   request_parts = url.parse( req.url );
   path_arguments = request_parts.path.split("/");
   
-
   if (path_arguments[1] == "ota") {
-    //var data_start = parseInt( path_arguments[2] );
-    console.log( req.url );
+    // (2) Determine the starting address of this OTA download request
     data_start = req.payload.readUInt32LE(0);
-    console.log("Requesting firmware starting from address " + data_start);
+    console.log("Requesting firmware starting from firmware address " + data_start);
     
-    res.end( firmware_binary.slice(data_start, firmware_binary.length) );
-    //res.end( firmware_binary );
+    // (3) Don't send data if the request is beyond the size of the OTA image
+    if ( data_start <= firmware_binary.length ) {
+      res.end( firmware_binary.slice(data_start, firmware_binary.length) );
+    }
     return;
   }
 
-/*
-  var data_start_position = parseInt( path_arguments[1] );
-  var data_length = parseInt( path_arguments[2] );
-  console.log( "Requesting data:\t" + data_start_position + "\t" + (data_start_position+data_length) );
-
-  if (data_start_position >= firmware_binary.length) {
-    //  If there's no more firmware, just send back an EOF message!
-    console.log("\tFirmware Binary: Reached End Of File.");
-    res.end("EOF");
-  } else {
-    //  Make sure we don't read past the end of the firmware.
-    var data_end_position = Math.min( (data_start_position + data_length), firmware_binary.length );
-    data = firmware_binary.slice( data_start_position, data_end_position );
-    console.log("\tSending " + data.length + " bytes.");
-    res.end( data );
-  }
-*/
 });
 
 server.listen( function() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "ota-server",
-  "description": "Server OTA images to nodes by HTTP request.",
-  "version": "0.0.1"
+  "description": "Server OTA images to nodes by COAP request.",
+  "version": "0.0.1",
+  "dependencies": {
+    "coap": ">=0.12.1"
+  }
 }


### PR DESCRIPTION
Rewrote the server to use CoAP instead of HTTP.  Changed the URL schema a bit.  CoAP uses blockwise transfer to send firmware data more quickly than HTTP.
